### PR TITLE
fix non-conforming main signature in C

### DIFF
--- a/Model/Language.hs
+++ b/Model/Language.hs
@@ -363,7 +363,7 @@ _start:
 languageDefaultContent Bash = [multiline|echo Hello World|]
 languageDefaultContent C = [multiline|#include <stdio.h>
 
-int main() {
+int main(void) {
     printf("Hello World!\n");
     return 0;
 }|]


### PR DESCRIPTION
`int main()` is not a valid signature for main according to the standard.
