### PR TITLE
use tab instead of soft tab

### DIFF
--- a/templates/widgets/editor.julius
+++ b/templates/widgets/editor.julius
@@ -9,6 +9,7 @@ window.Editor = (function() {
         editor.setTheme(theme);
         editor.setKeyboardHandler(keybindings);
         editor.getSession().setMode(#{toJSON $ languageAceMode lang});
+        editor.getSession().setUseSoftTabs(false);
         editor.setOptions({
             minLines: lineCount,
             maxLines: lineCount,


### PR DESCRIPTION
Hi @prasmussen, this is related to https://github.com/prasmussen/glot/issues/5. I propose this change to make tabs tabs, instead of 4 spaces, but it is up to you. Hard tabs makes it easier to write makefiles.
