### PR TITLE
Updated csharp default content

### DIFF
--- a/Model/Language.hs
+++ b/Model/Language.hs
@@ -467,6 +467,8 @@ int main() {
     return 0;
 }|]
 languageDefaultContent Csharp = [multiline|using System;
+using System.Collections.Generic;
+using System.Linq;
 
 class MainClass {
     static void Main() {


### PR DESCRIPTION
I added two very commonly used imports to the default C# language.

While these are not necessary to run the code, any new code written that includes a List, Set, Dictionary, etc will need these and they are not very memorable.