### PR TITLE
Change to abbreviated name SaC, update code example

### DIFF
--- a/config/languages.dhall
+++ b/config/languages.dhall
@@ -1068,7 +1068,7 @@ in    [ { id = "assembly"
           ] : List Book
         }
       , { id = "sac"
-        , name = "Single-Assignment C"
+        , name = "SaC"
         , logoName = "sac"
         , fileExtension = "sac"
         , editorConfig =
@@ -1079,7 +1079,7 @@ in    [ { id = "assembly"
           , exampleCode =
             ''
             int main () {
-                StdIO::show ("Hello World!");
+                StdIO::printf ("Hello World!");
                 return 0;
             }''
           }


### PR DESCRIPTION
Hi, I'd like to make a small change to the title name of the Single-Assignment C compiler, to SaC... it looks nicer all on one line. Also changed the code example slightly. Thanks!